### PR TITLE
Library2 subcomponents change

### DIFF
--- a/excelutils/excel_sbol_utils/library2.py
+++ b/excelutils/excel_sbol_utils/library2.py
@@ -1,5 +1,5 @@
 import sbol2
-import excel2sbol.helper_functions as hf
+import excel_sbol_utils.helpers as hf
 import re
 import logging
 # might be better if some of the ones like data sources were put in a library
@@ -93,7 +93,8 @@ def subcomponents(rowobj):
 		comp_ind = 0
 		variant_comps = {}
 		for ind, comp in enumerate(comp_list):
-			if "," in comp or type(rowobj.obj_dict[comp]['object']) == sbol2.combinatorialderivation.CombinatorialDerivation:
+			if "," in comp or type(rowobj.obj_dict[comp]['object']) == \
+									sbol2.combinatorialderivation.CombinatorialDerivation:
 				comp_list[ind] = f'{rowobj.obj.displayId}_subcomponent_{comp_ind}'
 				uri = f'{rowobj.obj.displayId}_subcomponent_{comp_ind}'
 				sub_comp = sbol2.ComponentDefinition(uri)
@@ -123,7 +124,7 @@ def subcomponents(rowobj):
 			rowobj.obj.variableComponents.add(var_comp)
 
 	else:
-		raise KeyError(f'The object type "{type(rowobj.obj)}" does not allow subcomponents. (sheet:{rowobj.sheet}, row:{rowobj.sht_row}, col:{rowobj.sht_col})')
+		raise KeyError(f'The object type "{type(rowobj.obj)}" does not allow subcomponents. (sheet:{rowobj.sheet}, row:{rowobj.sht_row}, col:{rowobj.col_cell_dict})')
 
 def dataSource(rowobj):
 	prefs = rowobj.col_cell_dict['pref']

--- a/excelutils/excel_sbol_utils/library2.py
+++ b/excelutils/excel_sbol_utils/library2.py
@@ -119,7 +119,7 @@ def subcomponents(rowobj):
 			rowobj.obj.variableComponents.add(var_comp)
 
 	else:
-		raise KeyError(f'The object type "{type(rowobj.obj)}" does not allow subcomponents. (sheet:{self.sheet}, row:{self.sht_row}, col:{self.sht_col})')
+		raise KeyError(f'The object type "{type(rowobj.obj)}" does not allow subcomponents. (sheet:{rowobj.sheet}, row:{rowobj.sht_row}, col:{rowobj.sht_col})')
 
 def dataSource(rowobj):
 	prefs = rowobj.col_cell_dict['pref']

--- a/excelutils/excel_sbol_utils/library2.py
+++ b/excelutils/excel_sbol_utils/library2.py
@@ -1,4 +1,5 @@
 import sbol2
+import excel2sbol.helper_functions as hf
 import re
 import logging
 # might be better if some of the ones like data sources were put in a library
@@ -68,6 +69,7 @@ def definedFunComponent(rowobj): #NOT IMPLEMENTED
     pass
 
 def subcomponents(rowobj):
+	sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, True)
 	if 'subcomp' in rowobj.col_cell_dict:
 		subcomps = list(rowobj.col_cell_dict['subcomp'].values())
 	if 'constraint' in rowobj.col_cell_dict:
@@ -91,7 +93,7 @@ def subcomponents(rowobj):
 		comp_ind = 0
 		variant_comps = {}
 		for ind, comp in enumerate(comp_list):
-			if "," in comp:
+			if "," in comp or type(rowobj.obj_dict[comp]['object']) == sbol2.combinatorialderivation.CombinatorialDerivation:
 				comp_list[ind] = f'{rowobj.obj.displayId}_subcomponent_{comp_ind}'
 				uri = f'{rowobj.obj.displayId}_subcomponent_{comp_ind}'
 				sub_comp = sbol2.ComponentDefinition(uri)
@@ -99,6 +101,8 @@ def subcomponents(rowobj):
 				rowobj.doc.add(sub_comp)
 				variant_comps[f'subcomponent_{comp_ind}'] = {'object': sub_comp, 'variant_list': comp}
 				comp_ind += 1
+			else:
+				comp_list[ind] = hf.check_name(comp_list[ind])
 
 		template = sbol2.ComponentDefinition(f'{rowobj.obj.displayId}_template')
 		template.displayId = f'{rowobj.obj.displayId}_template'


### PR DESCRIPTION
- Imported helper functions to use check_name function.
- Line 72 included due to template.assemblePrimaryStructure() not working with the typed URIs configuration setting when set to false.
- Added extra case for combinatorialDerivations to be added as variants instead of going through the usual pipeline.
- Added case for non-list and non-combinatorialDerivations to have their URI checked in order for them to be recognized.
