### PR TITLE
Added implementation of LinearDNAProducts by piggybacking

### DIFF
--- a/excelutils/excel_sbol_utils/library3.py
+++ b/excelutils/excel_sbol_utils/library3.py
@@ -77,10 +77,13 @@ def subcomponents(rowobj): #UPDATE TO WORK WITH CELL DICT, ALLOW CONSTRAINTS
 		for b in b_split:
 			try:
 				obj = rowobj.obj_dict[b]['object']
-				# rowobj.obj.variable_features.append(obj)
+				temp_var = sbol3.SubComponent(instance_of=obj)
+				oldobj.features.append(temp_var)
 			except:
 				newcomp = sbol3.Component(identity=b, types= sbol3.SBO_DNA, name=b)
-				# rowobj.obj.features.append(newcomp)
+				rowobj.doc.add(newcomp)
+				temp_var = sbol3.SubComponent(instance_of=newcomp)
+				rowobj.obj.features.append(temp_var)
 
 
 	# if type is compdef do one thing, if combdev do another, else error

--- a/excelutils/excel_sbol_utils/library3.py
+++ b/excelutils/excel_sbol_utils/library3.py
@@ -195,8 +195,23 @@ def finalProduct(rowobj):
 				sbol_objs_names = [x.name for x in sbol_objs]
 
 				doc.add(colec)
+				colec.members.append(rowobj.obj_uri)
 			else:
 				colec = sbol_objs[sbol_objs_names.index('FinalProducts')]
+				colec.members.append(rowobj.obj_uri)
+
+			if 'LinearDNAProducts' not in sbol_objs_names:
+				colec = sbol3.Collection('LinearDNAProducts', name='LinearDNAProducts')
+
+				sbol_objs = doc.objects
+				sbol_objs_names = [x.name for x in sbol_objs]
+
+				doc.add(colec)
+				colec.members.append(rowobj.obj_uri + '_ins')
+			else:
+				colec = sbol_objs[sbol_objs_names.index('LinearDNAProducts')]
+				colec.members.append(rowobj.obj_uri + '_ins')
+
 			
 			#add obj as member to final products
-			colec.members.append(rowobj.obj_uri)
+			


### PR DESCRIPTION
Used the finalProduct function for implementation of linearDNAProducts in the same manner as used in SBOL_utilities. The worry is that although yes, the collection's parts have the suffix 'ins', in simple_library.nt (From SBOL_utilities), some composite parts have _ins suffixes themselves, which isn't replicated in this code.